### PR TITLE
Use OT target list instead of Biomart for UniProt to HGNC id mapping

### DIFF
--- a/chemicalProbes_probeMiner_preprocessing.R
+++ b/chemicalProbes_probeMiner_preprocessing.R
@@ -22,7 +22,6 @@ setwd(working_dir)
 # Specify input file
 probe_miner_dump <- "probeminer_datadump_2019-07-01.txt"
 
-library('biomaRt')
 library("dplyr")
 library("tidyr")
 library("tibble")


### PR DESCRIPTION
Changes to the Probe Miner script so that Uniprot accessions are mapped to HGNC symbols using the Open Targets targets list instead of calling Biomart